### PR TITLE
Make bytes compatible with Python3

### DIFF
--- a/publisher/publisher.py
+++ b/publisher/publisher.py
@@ -95,8 +95,8 @@ def publish(notebook_name, url_path, page_title, page_description,
     kwargs.setdefault('page_type', 'u-guide')
     kwargs.setdefault('language', 'python')
 
-    with open('2015-06-30-' + fn.replace('.ipynb', '.html'), 'w') as f:
-        f.write('\n'.join([''
+    with open('2015-06-30-' + fn.replace('.ipynb', '.html'), 'wb') as f:
+        header = '\n'.join([''
                            '---',
                            'permalink: ' + url_path,
                            'description: ' + page_description.replace(':', '&#58;'),
@@ -106,13 +106,14 @@ def publish(notebook_name, url_path, page_title, page_description,
                            '\n'.join(['{}: {}'.format(k, v) for k, v in kwargs.items()]),
                            '---',
                            '{% raw %}'
-                           ]))
+                           ])
+        f.write(header.encode('utf8'))
         if uses_plotly_offline:
             f.write(
-                '<script type="text/javascript" '
+                ('<script type="text/javascript" '
                 '        src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.2/require.js">'
-                '</script>'
+                '</script>').encode('utf8')
             )
         f.write(html.encode('utf8'))
-        f.write('{% endraw %}')
+        f.write('{% endraw %}'.encode('utf8'))
     os.remove(tmpfn)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='publisher',
-    version='0.12',
+    version='0.13',
     author='chris p',
     author_email='chris@plot.ly',
     packages=['publisher'],


### PR DESCRIPTION
There was a new error in python3 wrt writing bytes and strings with the same file so I converted all the strings to bytes here and opened the file with "wb".

this resolves #3.

I tested this in python2 and python3 and it works.

cc @Kully 

```
! pip install git+https://github.com/michaelbabyn/publisher.git@patch-1 --upgrade
```